### PR TITLE
js: fix topic and payload offsets for publish frames

### DIFF
--- a/bindings/js/busrt/src/busrt.js
+++ b/bindings/js/busrt/src/busrt.js
@@ -390,15 +390,17 @@ class Client {
             throw "Invalid bus/rt frame";
           }
           frame.sender = frame.payload.slice(0, i).toString();
+          i += 1; // Move the cursor past the sender's null terminator
+
           if (frame.type == OP_PUBLISH) {
-            let t = frame.payload.indexOf(0);
+            let t = frame.payload.slice(i).indexOf(0);
             if (t == -1) {
               throw "Invalid bus/rt frame";
             }
-            frame.topic = frame.payload.slice(0, t).toString();
-            i += t + 2;
+            frame.topic = frame.payload.slice(i, i+t).toString();
+            i += t + 1; // Move the cursor past the topic's null terminator
           }
-          frame.payload_pos = i + 1;
+          frame.payload_pos = i;
           if (me.on_frame) {
             process.nextTick(() => me.on_frame(frame));
           }


### PR DESCRIPTION
There were a few things wrong here:

* The search for the topic's null terminator was starting from the beginning of the payload, rather than after the sender's null terminator
* The topic slice was also starting from the beginning of the payload
* The `i` cursor was getting an extra `+1`, presumably to skip the null bytes for both the sender and the topic, even though the sender's byte was already being skipped a couple of lines down

Now, the sender null byte is skipped earlier for clarity and the search/slice for the topic starts in the right place.